### PR TITLE
Add Docker support (frontend, backend, docker-compose)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+data.db
+migrations/
+.env
+.flaskenv
+.git

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# RUN apt-get update && apt-get install -y \
+#     gcc \
+#     libpq-dev \
+#     && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "application.py"]

--- a/backend/application.py
+++ b/backend/application.py
@@ -1,3 +1,14 @@
 from flaskr import create_app
 
 app = create_app()
+
+# for rule in app.url_map.iter_rules():
+#     print(rule)
+
+@app.route("/")
+def index():
+    return {"message": "Welcome to Todo App API"}
+
+if __name__ == "__main__":
+    # 0.0.0.0 makes Flask accessible outside the container
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+    container_name: flask-backend
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./backend:/app
+    environment:
+      FLASK_ENV: development
+      JWT_SECRET_KEY: super-secret
+      SECRET_KEY: super-secret
+    restart: always
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: react-frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend
+    restart: always

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD [ "npm", "run", "dev", "--", "--host" ]


### PR DESCRIPTION
Hi Remy,

I’ve added Docker support to simplify running the project:

- Dockerfile for frontend
- Dockerfile for backend
- docker-compose.yml to run frontend and backend together

Additionally, I made a small update in application.py to ensure compatibility with the Docker setup.

With these changes, the project can be run locally with:

"docker-compose up"

This should help with consistent environment setup and make onboarding easier for new contributors.

Please let me know if you’d like any adjustments or improvements!